### PR TITLE
Create pgsql-rw-register

### DIFF
--- a/test/examples/pgsql-rw-register
+++ b/test/examples/pgsql-rw-register
@@ -1,0 +1,151 @@
+local pgsql =  require ("luasql.postgres")
+local os = require('os')
+local molly = require('molly')
+local log = require('molly.log')
+
+-- `pg_rw_register` is a client that performs on database two operations:
+-- `read` and `write`. Method `invoke` must apply these operations to a
+-- database instance.
+local pg_rw_register = molly.client.new()
+
+
+
+-- open database
+pg_rw_register.open = function(self)
+
+    self.env = assert (pgsql.postgres())
+    self.con = assert (self.env:connect('test2', 'postgres', nil, "127.0.0.1", 5432))
+    
+    return true
+end
+
+
+pg_rw_register.setup = function(self)
+    print('setup')
+    assert(self.con:execute("CREATE TABLE IF NOT EXISTS rw_register (id int, val int, ver int default 1)"))
+    assert(self.con:execute("CREATE TABLE IF NOT EXISTS log_register ( sm int default 0)"))
+    assert(self.con:execute("TRUNCATE TABLE rw_register"))
+    assert(self.con:execute("TRUNCATE TABLE log_register"))
+    
+    -- assert(self.con:execute("SELECT create_distributed_table('rw_register', 'id', shard_count=>2"))
+    return true
+end
+
+
+local threads = 5
+
+local OP_TYPE = 1
+local OP_VAL = 3
+local KEY_ID = 1
+local check = 100
+local iterations = check * 2 
+
+
+pg_rw_register.invoke = function(self, op)
+    -- print('invoke')
+    local val = op.value[1]
+    local type = 'ok'
+    if val[OP_TYPE] == 'r' then
+
+        local res = self.con:execute(string.format('SELECT val FROM rw_register WHERE id = %d', KEY_ID))
+        local row = res:fetch ({}, "a")
+        
+        if row == nil then
+            val[OP_VAL] = nil
+        else
+            val[OP_VAL] = row.val
+        end
+
+        -- if val[OP_VAL] == nil then
+        --    print(string.format('r KEY_ID=%d val[%d]=nil', KEY_ID, OP_VAL))
+        -- else
+        --     print(string.format('r KEY_ID=%d val[%d]=%d', KEY_ID, OP_VAL, val[OP_VAL]))
+        -- end
+
+    elseif val[OP_TYPE] == 'w' then
+
+        -- print(string.format('w KEY_ID=%d val[%d]=%d', KEY_ID, OP_VAL, val[OP_VAL]))
+        local sql = string.format('INSERT INTO rw_register(id,val) VALUES (%d, %d)', KEY_ID, val[OP_VAL])
+        local ok = assert(self.con:execute(sql))
+        if ok == false then
+            print('insert fail')
+            type = 'fail'
+        end
+    else
+        error('Unknown operation')
+    end
+
+    return {
+        value = { val },
+        f = op.f,
+        process = op.process,
+        type = type,
+    }
+end
+
+pg_rw_register.teardown = function(self)
+    print('teardown')
+    -- local changes = self.db:total_changes()
+        
+    local res = assert(self.con:execute('SELECT sum(ver) as sum FROM rw_register'))
+    local row = res:fetch ({}, "a")
+    -- assert(changes == 500, string.format('Number of operations is wrong (%d != 500)', changes))
+    
+    if tonumber(row.sum) == check then
+        log.debug('Total changes in Postgres DB is Ok [excepted %s]', row.sum )
+    else
+        log.debug('Total changes in Postgres DB is fail [excepted %s  call %d]', row.sum, check )
+    end
+
+    assert(self.con:execute("INSERT INTO log_register VALUES(1)"))
+
+    print('class:',self)
+    return true
+end
+
+-- finalize class
+pg_rw_register.close = function(self)
+    print('close ')
+    self.env:close()
+    self.con:close()
+    return true
+end
+
+
+local test_options = {
+    create_reports = true,
+    threads = threads,
+    nodes = {
+        'node 1',
+        'node 2',
+        'node 3',
+        'node 4',
+        'node 5',
+        -- 'node 6',
+    },
+}
+
+
+-- original tests option 
+-- local test_options = {
+--     create_reports = true,
+--     threads = 5,
+--     nodes = {
+--         '1',
+--     },
+-- }
+
+
+local ok, err = molly.runner.run_test({
+    client = pg_rw_register,
+    generator = molly.tests.rw_register_gen():take(iterations),
+}, test_options)
+
+if not ok then
+    print('Test has failed:', err)
+end
+
+if os.getenv('DEV') ~= 'ON' then
+    os.remove('history.json')
+    os.remove('history.txt')
+end


### PR DESCRIPTION
The rw-register test for postgreSQL. This molly framework could be have the error:
After fist call invoke method the postgresql connection was closed:

The trace codeh:  

	Run PostgreSQL examples with Tarantool
	setup
	setup
	setup
	setup
	setup
	teardown
	class:	table: 0x7f7ef8691d40
	close 
	teardown
	[INFO  2024-06-13 10:50:29:87823 ]: ERROR: test/examples/pgsql-rw-register.lua:90: calling 'execute' on bad self (LuaSQL: connection is closed)
	teardown
	[INFO  2024-06-13 10:50:29:87871 ]: ERROR: test/examples/pgsql-rw-register.lua:90: calling 'execute' on bad self (LuaSQL: connection is closed)
	teardown
	[INFO  2024-06-13 10:50:29:87889 ]: ERROR: test/examples/pgsql-rw-register.lua:90: calling 'execute' on bad self (LuaSQL: connection is closed)
	teardown
	[INFO  2024-06-13 10:50:29:87908 ]: ERROR: test/examples/pgsql-rw-register.lua:90: calling 'execute' on bad self (LuaSQL: connection is closed)

